### PR TITLE
Feat: Variants (Entry, VariantGroup & Type support) & package version bump #107

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@contentstack/app-sdk",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@contentstack/app-sdk",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "license": "MIT",
             "dependencies": {
                 "loader-utils": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@contentstack/app-sdk",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "types": "dist/src/index.d.ts",
     "description": "The Contentstack App SDK allows you to customize your Contentstack applications.",
     "main": "dist/index.js",

--- a/src/stack/api/content-type/entry.ts
+++ b/src/stack/api/content-type/entry.ts
@@ -9,6 +9,7 @@ import {
     includeSchema,
     includeReference,
 } from "../../utils";
+import { GenericObjectType } from "../../../types/common.types";
 
 let connection = {};
 let contentTypeUid = "";
@@ -374,6 +375,55 @@ class Entry extends Base {
         }
         this._query.locale = locale;
         return this.fetch("updateEntry", payload);
+    }
+    /**
+     * @see {@link https://www.contentstack.com/docs/apis/content-management-api| fetch variant}
+     * @name Stack#ContentType#Entry#fetchVariant
+     * @function
+     * @description This call allows you to fetch variant customization of an entry.
+     * @param {string} variant_uid - parameter for the request
+     * @example appSDK.stack.ContentType('contenttype_uid').Entry('bltsomething123').fetchVariant('variant_uid').then(...).catch(...);
+     * @return {external:Promise}
+     */
+
+    fetchVariant(variant_uid: string) {
+        if (!variant_uid || typeof variant_uid !== "string") {
+            return Promise.reject(new Error("Kindly provide valid parameters"));
+        }
+        this._query.variant_uid = variant_uid;
+        return this.fetch("fetchVariant");
+    }
+
+    /**
+     * @see {@link https://www.contentstack.com/docs/apis/content-management-api| update variant}
+     * @name Stack#ContentType#Entry#updateVariant
+     * @function
+     * @description This call allows you to update variant customization of an entry.
+     * @param  {string} variant_uid - parameter for the request
+     * @param  {object} payload - parameter for the request
+     * @example appSDK.stack.ContentType('contenttype_uid').Entry('bltsomething123').updateVariant('variant_uid', 
+     * { "entry": {
+            "title": "test variant entry",
+             "url": "/variant-url",
+             "_variant": {
+                "_change_set": ["title", "url"]
+            }
+        }
+        }).then(...).catch(...);
+     * @return {external:Promise}
+     */
+
+    updateVariant(variant_uid: string, payload: GenericObjectType) {
+        if (
+            !variant_uid ||
+            typeof variant_uid !== "string" ||
+            typeof payload !== "object" ||
+            payload instanceof Array
+        ) {
+            return Promise.reject(new Error("Kindly provide valid parameters"));
+        }
+        this._query.variant_uid = variant_uid;
+        return this.fetch("updateVariant", payload);
     }
 }
 

--- a/src/stack/index.ts
+++ b/src/stack/index.ts
@@ -3,6 +3,8 @@ import ContentType from './api/content-type/index';
 import { onData, onError } from "../utils/utils";
 import { BranchDetail, GetAllStacksOptions, StackAdditionalData, StackDetail, StackSearchQuery } from '../types/stack.types';
 import { IManagementTokenDetails } from '../types';
+import  VariantGroup  from "../variantGroup";
+import { GenericObjectType } from "../types/common.types";
 
 
 /**
@@ -18,6 +20,7 @@ class Stack {
   _data: StackDetail
   ContentType: any 
   Asset: any 
+  VariantGroup: any
   private _currentBranch: BranchDetail | null = null;
 
 
@@ -42,6 +45,16 @@ class Stack {
      * @example appSDK.stack.Asset('asset_uid')
      * */
     this.Asset = Asset(connection);
+
+    /**
+     * @constructor
+     * @hideconstructor
+     * @desc An initializer is responsible for creating an VariantGroup object.
+     * @see {@link https://www.contentstack.com/docs/apis/content-management-api/| VariantGroup}
+     * @param {string} uid - variant group uid.
+     * @example appSDK.stack.VariantGroup('variant_group_uid')
+     * */
+    this.VariantGroup = VariantGroup(connection);
 
     const currentBranch = additionalData.currentBranch || ""
 
@@ -271,6 +284,17 @@ class Stack {
      */
     getCurrentBranch(): BranchDetail | null {
       return this._currentBranch;
+    }
+
+    /**
+     * Returns variant groups of the current stack.
+     * @returns variant groups of the current stack
+     */
+    getVariantGroups(query = {}, params = {}) {
+      const optionParams: GenericObjectType = params;
+      optionParams.query = query;
+      const options = { params: optionParams, action: 'getVariantGroups' };
+      return this._connection.sendToParent('stackQuery', options).then(onData).catch(onError);
     }
 }
 

--- a/src/types/entry.types.ts
+++ b/src/types/entry.types.ts
@@ -1,5 +1,5 @@
 import Field from "../field";
-import { AnyProperty } from "./common.types";
+import { AnyProperty, GenericObjectType } from "./common.types";
 
 export declare interface IGetFieldOptions {
     /**
@@ -47,4 +47,6 @@ export interface Entry extends AnyProperty {
     publish_details: Array<any>;
     locale: string;
     url?: string;
+    _variant?: GenericObjectType ;
+    variant_id?: string
 }

--- a/src/variantGroup/index.ts
+++ b/src/variantGroup/index.ts
@@ -1,0 +1,64 @@
+import Base from "../stack/api/base";
+import { GenericObjectType } from "../types/common.types";
+
+/**
+ * Class representing the Variant Group.
+ */
+
+let connection = {};
+
+class VariantGroup extends Base {
+    constructor(uid: string) {
+        if (!uid) {
+            throw new Error("uid is required");
+        }
+        super(uid);
+        this._query = {};
+        return this;
+    }
+
+    static get connection() {
+        return connection;
+    }
+    /**
+     * @function
+     * @name Stack#VariantGroup#createVariant
+     * @description This method creates a new variant in a group.
+     * @example appSDK.stack.VariantGroup("variant_group_uid").createVariant(variant_payload);
+     * @return {external:Promise}
+     */
+    createVariant(payload: GenericObjectType) {
+        return this.fetch("createVariant", payload);
+    }
+    /**
+     * @function
+     * @name Stack#VariantGroup#getVariantsByGroup
+     * @description This method returns all the variants within a group.
+     * @example appSDK.stack.VariantGroup("variant_group_uid").getVariantsByGroup();
+     * @return {external:Promise}
+     */
+    getVariantsByGroup() {
+        return this.fetch("getVariantsByGroup");
+    }
+
+    /**
+     * @function
+     * @name Stack#VariantGroup#getVariantsByGroup#deleteVariant
+     * @description This method deletes a specified variant from a group.
+     * @example appSDK.stack.VariantGroup("variant_group_uid").deleteVariant("variant_uid");
+     * @return {external:Promise}
+     */
+    deleteVariant(variant_uid: string) {
+        this._query.variant_uid = variant_uid;
+        return this.fetch("deleteVariant");
+    }
+}
+
+export default (uiConnection: GenericObjectType) => {
+    connection = uiConnection;
+    return new Proxy(VariantGroup, {
+        apply(Target: any, thisArg, argumentsList: any[]) {
+            return new Target(...argumentsList);
+        },
+    });
+};


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1SuRlcwYxJfuoHCuxCg7r5h9cuQvzNTDs%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=nkEnz5X)

## Changes: 
- Package version bump: v2.0.1 --> v2.0.2
- Variant Entry type support.
- VariantGroup addition to support group-level operations.
- Entry-level handlers to create/fetch/update variant.