### PR TITLE
fix: field not found issue for custom field and field modifier

### DIFF
--- a/__test__/uiLocation.test.ts
+++ b/__test__/uiLocation.test.ts
@@ -2,7 +2,6 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 
 import postRobot from "post-robot";
 
-import UiLocation from "../src/uiLocation";
 import {
     IAppConfigInitData,
     IAssetSidebarInitData,
@@ -14,8 +13,9 @@ import {
     LocationType,
     Region,
 } from "../src/types";
-import { RequestOption } from "../src/types/common.types";
 import { RequestConfig } from "../src/types/api.type";
+import { RequestOption } from "../src/types/common.types";
+import UiLocation from "../src/uiLocation";
 
 jest.mock("post-robot");
 jest.mock("wolfy87-eventemitter");
@@ -310,7 +310,13 @@ describe("UI Location", () => {
             const config = await uiLocation.getConfig();
             expect(config).toEqual({});
             expect(postRobotSendToParentMock).toHaveBeenLastCalledWith(
-                "getConfig", {"context": {"extensionUID": "extension_uid", "installationUID": "installation_uid"}}
+                "getConfig",
+                {
+                    context: {
+                        extensionUID: "extension_uid",
+                        installationUID: "installation_uid",
+                    },
+                }
             );
         });
     });
@@ -458,6 +464,9 @@ describe("UI Location", () => {
             const uiLocation = new UiLocation({
                 ...initData,
                 type: "FIELD_MODIFIER_LOCATION",
+                schema: {
+                    $uid: "",
+                },
             } as IFieldModifierLocationInitData);
             expect(uiLocation.location.FieldModifierLocation).toBeDefined();
             expect(uiLocation.location.FieldModifierLocation).toHaveProperty(
@@ -478,6 +487,9 @@ describe("UI Location", () => {
             const uiLocation = new UiLocation({
                 ...initData,
                 type: "FULL_PAGE_LOCATION",
+                schema: {
+                    $uid: "",
+                },
             } as IFullPageLocationInitData);
             expect(uiLocation.location.FullPage).toBeDefined();
             expect(uiLocation.location.FullPage).toHaveProperty("stack");
@@ -487,6 +499,9 @@ describe("UI Location", () => {
             const uiLocation = new UiLocation({
                 ...initData,
                 type: "FIELD",
+                schema: {
+                    $uid: "",
+                },
             } as IFieldInitData);
             expect(uiLocation.location.CustomField).toBeDefined();
             expect(uiLocation.location.CustomField).toHaveProperty("field");
@@ -502,6 +517,9 @@ describe("UI Location", () => {
             const uiLocation = new UiLocation({
                 ...initData,
                 type: "",
+                schema: {
+                    $uid: "",
+                },
             } as any);
             expect(uiLocation.location.CustomField).toBeDefined();
             expect(uiLocation.location.CustomField).toHaveProperty("field");

--- a/src/uiLocation.ts
+++ b/src/uiLocation.ts
@@ -2,10 +2,9 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import postRobot from "post-robot";
 import EventEmitter from "wolfy87-eventemitter";
 
+import { AppConfig } from "./appConfig";
 import AssetSidebarWidget from "./AssetSidebarWidget";
 import ContentTypeSidebarWidget from "./ContentTypeSidebarWidget";
-import { IRTEPluginInitializer } from "./RTE/types";
-import { AppConfig } from "./appConfig";
 import Entry from "./entry";
 import EventRegistry from "./EventRegistry";
 import Field from "./field";
@@ -14,6 +13,7 @@ import FieldModifierLocationField from "./fieldModifierLocation/field";
 import FieldModifierLocationFrame from "./fieldModifierLocation/frame";
 import Metadata from "./metadata";
 import Modal from "./modal";
+import { IRTEPluginInitializer } from "./RTE/types";
 import Stack from "./stack";
 import Store from "./store";
 import {
@@ -22,20 +22,20 @@ import {
     IDashboardWidget,
     IFieldModifierLocation,
     IFullPageLocation,
+    IGlobalFullPageLocation,
     IRTEInitData,
     ISidebarWidget,
     InitializationData,
     LocationType,
     Manifest,
-    IGlobalFullPageLocation,
     RegionType,
 } from "./types";
+import { ContentstackEndpoints } from "./types/api.type";
 import { GenericObjectType } from "./types/common.types";
 import { User } from "./types/user.types";
+import { dispatchAdapter, dispatchApiRequest } from "./utils/adapter";
 import { formatAppRegion, onData, onError } from "./utils/utils";
 import Window from "./window";
-import { dispatchApiRequest, dispatchAdapter } from "./utils/adapter";
-import { ContentstackEndpoints } from "./types/api.type";
 
 const emitter = new EventEmitter();
 
@@ -263,6 +263,11 @@ class UiLocation {
 
             case LocationType.FIELD_MODIFIER_LOCATION: {
                 initializationData.self = true;
+                // Fix for FIELD_NOT_FOUND issue introduced in v2.4.0
+                // Schema field UIDs contain the complete field path, including parent paths
+                // Custom Field and Field Modifier UIDs currently contain only the field UID
+                // As a result, schema field lookup fails for nested fields because the full path is required
+                // MKT-18455
                 this.location.FieldModifierLocation = {
                     entry: new FieldModifierLocationEntry(
                         initializationData,
@@ -273,7 +278,10 @@ class UiLocation {
                         currentBranch: initializationData.currentBranch,
                     }),
                     field: new FieldModifierLocationField(
-                        initializationData,
+                        {
+                            ...initializationData,
+                            uid: initializationData.schema.$uid,
+                        },
                         postRobot,
                         emitter
                     ),
@@ -309,8 +317,20 @@ class UiLocation {
             case LocationType.FIELD:
             default: {
                 initializationData.self = true;
+                // Fix for FIELD_NOT_FOUND issue introduced in v2.4.0
+                // Schema field UIDs contain the complete field path, including parent paths
+                // Custom Field and Field Modifier UIDs currently contain only the field UID
+                // As a result, schema field lookup fails for nested fields because the full path is required
+                // MKT-18455
                 this.location.CustomField = {
-                    field: new Field(initializationData, postRobot, emitter),
+                    field: new Field(
+                        {
+                            ...initializationData,
+                            uid: initializationData.schema.$uid,
+                        },
+                        postRobot,
+                        emitter
+                    ),
                     fieldConfig: initializationData.field_config,
                     entry: new Entry(initializationData, postRobot, emitter),
                     stack: new Stack(initializationData.stack, postRobot, {
@@ -400,9 +420,7 @@ class UiLocation {
                     ]);
                 }
                 if (event.data.name === "onError") {
-                    emitter.emitEvent("onError", [
-                        event.data.data,
-                    ]);
+                    emitter.emitEvent("onError", [event.data.data]);
                 }
             });
         } catch (err) {
@@ -436,7 +454,12 @@ class UiLocation {
             return Promise.resolve(this.config);
         }
         return this.postRobot
-            .sendToParent("getConfig", {context:{installationUID:this.installationUID, extensionUID:this.locationUID}})
+            .sendToParent("getConfig", {
+                context: {
+                    installationUID: this.installationUID,
+                    extensionUID: this.locationUID,
+                },
+            })
             .then(onData)
             .catch(onError);
     };
@@ -490,7 +513,7 @@ class UiLocation {
 
     api = (url: string, option?: RequestInit): Promise<Response> =>
         dispatchApiRequest(url, option) as Promise<Response>;
-    
+
     /**
      * Method used to create an adapter for management sdk.
      */


### PR DESCRIPTION
- Custom Field and Field Modifier UIDs currently contain only the field UID.
- Finding field from schema requires the complete field path so that the correct field definition can be resolved from the content type schema.
- For fields that are not nested inside Groups, Modular Blocks, or Global Fields, everything worked correctly because the field UID and the full field path are effectively the same.
- However, once a field is nested within another field structure, the full path differs from the field UID. As a result, the schema field could not be resolved correctly, leading to a FIELD_NOT_FOUND error.
- [MKT-18455](https://contentstack.atlassian.net/browse/MKT-18455)

[MKT-18455]: https://contentstack.atlassian.net/browse/MKT-18455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ